### PR TITLE
feat(kcd-recompile): watch deeply if the expression is an object

### DIFF
--- a/resources/kcd/directives/kcd-recompile.js
+++ b/resources/kcd/directives/kcd-recompile.js
@@ -37,7 +37,7 @@ angular.module('kcd.directives').directive('kcdRecompile', ['$parse', function($
         }
 
         recompile();
-      });
+      }, typeof $parse(attrs.kcdRecompile)(scope) === 'object');
     }
   };
 }]);


### PR DESCRIPTION
Setup a deep `$watch` if the given expression to `kcd-recompile` references an `object`.

Lacking changes in Docs/Tests(_well..._) for this addition, so it may need some revision. 

Closes #2 
