### PR TITLE
(kcd-recompile) Fix orphaned watchers on recompile because no scope.$destroy

### DIFF
--- a/resources/kcd/directives/kcd-recompile.js
+++ b/resources/kcd/directives/kcd-recompile.js
@@ -9,7 +9,7 @@ angular.module('kcd.directives').directive('kcdRecompile', ['$parse', function($
       compile();
 
       function compile() {
-        transclude(scope, function(clone, clonedScope) {
+        transclude(scope.$new(false, scope), function(clone, clonedScope) {
           // transclude creates a clone containing all children elements;
           // as we assign the current scope as first parameter, the clonedScope is the same
           previousElements = clone;

--- a/resources/kcd/directives/kcd-recompile.js
+++ b/resources/kcd/directives/kcd-recompile.js
@@ -4,6 +4,7 @@ angular.module('kcd.directives').directive('kcdRecompile', ['$parse', function($
     transclude: true,
     link: function link(scope, $el, attrs, ctrls, transclude) {
       var previousElements;
+      var previousScope;
 
       compile();
 
@@ -12,6 +13,7 @@ angular.module('kcd.directives').directive('kcdRecompile', ['$parse', function($
           // transclude creates a clone containing all children elements;
           // as we assign the current scope as first parameter, the clonedScope is the same
           previousElements = clone;
+          previousScope = clonedScope;
           $el.append(clone);
         });
       }
@@ -21,6 +23,9 @@ angular.module('kcd.directives').directive('kcdRecompile', ['$parse', function($
           previousElements.remove();
           previousElements = null;
           $el.empty();
+        }
+        if (previousScope) {
+          previousScope.$destroy();
         }
 
         compile();


### PR DESCRIPTION
The changes to allow kcd-recompile to work on an ng-repeat made it so that if any child watchers are present on recompile, they are be orphaned and the watch count continues to go up with each recompile. By creating a new scope for the transclusion and then destroying it on recompile, we get the behavior we want.

PS - You can see this happening on http://kentcdodds.com/kcd-angular/#/kcd-recompile when you go over the Favorite Crazy Number.
